### PR TITLE
Changed from port in transport from 25 to 587

### DIFF
--- a/doc-source/send-email-exim.md
+++ b/doc-source/send-email-exim.md
@@ -27,7 +27,7 @@ These instructions assume that you want to use Amazon SES in the US West \(Orego
       ```
       1. ses_smtp:
       2. driver = smtp
-      3. port = 25
+      3. port = 587
       4. hosts_require_auth = *
       5. hosts_require_tls = *
       ```


### PR DESCRIPTION
The Exim transport configuration snippet sets the ses_smtp: transport to connect to SES on TCP:25. If you configure this on an EC2 instance - you will run into difficulty as AWS prevents excessive egress connections from EC2 to TCP:25 by default, for obvious reasons. 

Changing this to TCP:587, such that this transport will use the SMTP submission port, and avoid this issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
