### PR TITLE
3 missing ses enabled regions added to example.

### DIFF
--- a/doc-source/smtp-credentials.md
+++ b/doc-source/smtp-credentials.md
@@ -131,7 +131,7 @@ def main():
     parser.add_argument('--region',
             help='The name of the AWS Region that the SMTP password will be used in.',
             required=True,
-            choices=['us-east-1','us-west-2','eu-west-1'],
+            choices=['us-east-1','us-west-2','eu-west-1','eu-central-1','ap-southeast-2','ap-south1'],
             action="store")
     args = parser.parse_args()
 


### PR DESCRIPTION
SES has been available in 3 new regions on oct 30. 2019, these new regions are missing from this SES credentials "calculator". Tested & verified to work on eu-central-1, so assumption is that the other 2 new ones work too.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
