### PR TITLE
Exemplify that "Query" doesn't only mean to *query*

### DIFF
--- a/doc-source/query-interface.md
+++ b/doc-source/query-interface.md
@@ -1,6 +1,6 @@
 # Amazon SES Query API<a name="query-interface"></a>
 
-This section describes how to make Query requests to Amazon SES\. The various topics acquaint you with the Amazon SES Query interface, the components of a request, how to authenticate a request, and the content of responses\.
+This section describes how to make Query requests to Amazon SES\, for [actions](https://docs.aws.amazon.com/ses/latest/APIReference/API_Operations.html) such as `SendEmail`\. The various topics acquaint you with the Amazon SES Query interface, the components of a request, how to authenticate a request, and the content of responses\.
 + For information about Query requests, see [Query Requests and Amazon SES](query-interface-requests.md)\.
 + For information about request authentication, see [Request Authentication and Amazon SES](query-interface-authentication.md)\.
 + For examples of GET and POST requests, see [GET and POST Examples for Amazon SES](query-interface-examples.md)\.


### PR DESCRIPTION
New to SES. I found "Query" to be confusing/misleading, thinking it would only allow me to **query** something about SES, like scheduled emails, or receipts. But no, the "Query" API is used to "SendEmail" as well.