### PR TITLE
Corrected wrong email address in exim command.

### DIFF
--- a/doc-source/send-email-exim.md
+++ b/doc-source/send-email-exim.md
@@ -61,7 +61,7 @@ This command might differ depending on which operating system you use\.
    1. Enter the following command:
 
       ```
-      exim -v sender@example.com
+      exim -v recipient@example.com
       ```
 
       In the preceding command, replace *recipient@example\.com* with the address that you want to send the message to\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The address of the recipient is _sender@example.com_ so it is misleading. Also, the comment after refers to the recipient's email. Typo maybe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
