### PR TITLE
Correcting title from `fmail` to `email`

### DIFF
--- a/doc-source/receiving-email-receipt-rules.md
+++ b/doc-source/receiving-email-receipt-rules.md
@@ -1,4 +1,4 @@
-# Creating receipt rules for Amazon SES fmail receiving<a name="receiving-email-receipt-rules"></a>
+# Creating receipt rules for Amazon SES email receiving<a name="receiving-email-receipt-rules"></a>
 
 Receipt rules let you specify what Amazon SES does with email it receives for the email addresses or domains you own\. A receipt rule contains a condition and an ordered list of actions\. If the recipient of an incoming email matches a recipient specified in the conditions for the receipt rule, then Amazon SES performs the actions specified in that receipt rule\. For more information about the role of receipt rules in the email\-receiving process, see [Email receiving concepts](receiving-email-concepts.md)\.
 


### PR DESCRIPTION
I saw the title was wrong, and just trying to leave things in a better place than I found them. Cheers!

*Updated title to correct spelling of email*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
