### PR TITLE
Added example for PrincipalOrgID global condition key

### DIFF
--- a/doc-source/sending-authorization-policy-examples.md
+++ b/doc-source/sending-authorization-policy-examples.md
@@ -95,6 +95,32 @@ The following example policy grants permission to Amazon Cognito to send from id
 20. }
 ```
 
+The following example policy grants permission to all accounts within an AWS Organization to send from identity *example\.com*\. The AWS Organization is specified using the [PrincipalOrgID](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgid) global condition key.
+
+```
+ 1. {
+ 2.   "Id":"ExampleAuthorizationPolicy",
+ 3.   "Version":"2012-10-17",
+ 4.   "Statement":[
+ 5.     {
+ 6.       "Sid":"AuthorizeOrg",
+ 7.       "Effect":"Allow",
+ 8.       "Resource":"arn:aws:ses:us-east-1:888888888888:identity/example.com",
+ 9.       "Principal":"*",
+ 10.      "Action":[
+ 11.        "SES:SendEmail",
+ 12.        "SES:SendRawEmail"
+ 13.      ],
+ 14.      "Condition":{
+ 15.        "StringEquals":{
+ 16.          "aws:PrincipalOrgID":"o-xxxxxxxxxxx"
+ 17.        }
+ 18.      }
+ 19.    }
+ 20.  ]
+ 21. }
+```
+
 ## Restricting the "From" Address<a name="sending-authorization-policy-example-from"></a>
 
 If you use a verified domain, you may want to create a policy that only allows the delegate sender to send from a specified email address\. To restrict the "From" address, you set a condition on the key called *ses:FromAddress*\. The following policy enables AWS account ID *123456789012* to send from the identity *example\.com*, but only from the email address *sender@example\.com*\.


### PR DESCRIPTION
When using a domain with many accounts, it may be easier to authorize the entire organization instead of individual account principals.  Using the global condition key is a way to do this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.