### PR TITLE
Update smtp-credentials with backwards compatible changes for Python2

### DIFF
--- a/doc-source/smtp-credentials.md
+++ b/doc-source/smtp-credentials.md
@@ -125,7 +125,7 @@ def calculateKey(secretAccessKey, region):
     signature = sign(signature, SERVICE)
     signature = sign(signature, TERMINAL)
     signature = sign(signature, MESSAGE)
-    signatureAndVersion = bytes([VERSION]) + signature
+    signatureAndVersion = b'\x04' + bytes(signature)
     smtpPassword = base64.b64encode(signatureAndVersion)
     print(smtpPassword.decode('utf-8'))
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating Python instructions for generating SMTP password to be backwards compatible with Python 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
