### PR TITLE
Update sending-email-suppression-list.md

### DIFF
--- a/doc-source/sending-email-suppression-list.md
+++ b/doc-source/sending-email-suppression-list.md
@@ -94,7 +94,7 @@ The following procedure assumes that you've already installed the AWS CLI\. For 
 
   ```
   aws sesv2 put-suppressed-destination \
-  --email-address recipient@example.com \
+  --email-address="recipient@example.com" \
   --reason BOUNCE
   ```
 
@@ -103,7 +103,7 @@ The following procedure assumes that you've already installed the AWS CLI\. For 
 
   ```
   aws sesv2 put-suppressed-destination `
-  --email-address recipient@example.com `
+  --email-address="recipient@example.com" `
   --reason BOUNCE
   ```
 
@@ -296,7 +296,7 @@ The following procedure assumes that you've already installed the AWS CLI\. For 
 
   ```
   aws sesv2 delete-suppressed-destination \
-  --email-address recipient@example.com
+  --email-address="recipient@example.com"
   ```
 
 ------
@@ -304,7 +304,7 @@ The following procedure assumes that you've already installed the AWS CLI\. For 
 
   ```
   aws sesv2 delete-suppressed-destination `
-  --email-address recipient@example.com
+  --email-address="recipient@example.com"
   ```
 
 ------


### PR DESCRIPTION
I ran into a case where the example commands for deleting an email from the email suppression list would fail, due to the email having a leading hyphen, like `-myemail@example.com`, as well as fail on cases where it contained a single quote, like `first.o'last@example.com`.

Using the explicit form of `--option="value"` solves these cases.

This is a known problem for other cli endpoints as well https://github.com/aws/aws-cli/issues/1135

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
