### PR TITLE
Update smtp-credentials.md

### DIFF
--- a/doc-source/smtp-credentials.md
+++ b/doc-source/smtp-credentials.md
@@ -133,7 +133,7 @@ def sign(key, msg):
 
 def calculate_key(secret_access_key, region):
     if region not in SMTP_REGIONS:
-        raise ValueError(f"The {region} Region doesn't have an SMTP endpoint.")
+        raise ValueError("The {region} Region doesn't have an SMTP endpoint.")
 
     signature = sign(("AWS4" + secret_access_key).encode('utf-8'), DATE)
     signature = sign(signature, region)


### PR DESCRIPTION
Fix typo in Python script.

When I copied and pasted the Python script it failed due to invalid syntax. Closer inspection revealed a typo, which this commit fixes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
