### PR TITLE
Clarify need to run script with Python 3

### DIFF
--- a/doc-source/smtp-credentials.md
+++ b/doc-source/smtp-credentials.md
@@ -168,6 +168,8 @@ To obtain your SMTP password by using this script, save the preceding code as `s
 python path/to/smtp_credentials_generate.py wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY us-east-1
 ```
 
+Note: You will need to run the above command with `python3` if the default version of `python` is 2.x.
+
 In the preceding command, do the following:
 + Replace *path/to/* with the path to the location where you saved `smtp_credentials_generate.py`\.
 + Replace *wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY* with the secret access key that you want to convert into an SMTP password\.


### PR DESCRIPTION
Running the Python script with version 2 results in a syntax error. The script needs to be run with Python version 3.

*Issue: https://github.com/awsdocs/amazon-ses-developer-guide/issues/40*

*Description of changes:*

Adds a note to make it clear that the Python script needs to be run with version 3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
