### PR TITLE
Fix smtp-credentials converter error

### DIFF
--- a/doc-source/smtp-credentials.md
+++ b/doc-source/smtp-credentials.md
@@ -133,7 +133,7 @@ def sign(key, msg):
 
 def calculate_key(secret_access_key, region):
     if region not in SMTP_REGIONS:
-        raise ValueError(f"The {region} Region doesn't have an SMTP endpoint.")
+        raise ValueError("The {region} Region doesn't have an SMTP endpoint.")
 
     signature = sign(("AWS4" + secret_access_key).encode('utf-8'), DATE)
     signature = sign(signature, region)


### PR DESCRIPTION
Having f in ValueError(f" causes the error:
 ./ses_secret_converter2.py asdfasdf asdfasdf
  File "./smtp_credentials_generate.py", line 39
    raise ValueError(f'The {region} Region doesn not have an SMTP endpoint.')
Script works fine once the "f" is removed

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
