### PR TITLE
Leave Name field blank when using R53 Console

### DIFF
--- a/doc-source/receiving-email-mx-record.md
+++ b/doc-source/receiving-email-mx-record.md
@@ -25,7 +25,8 @@ To complete the following procedure, you have to be able to modify the DNS recor
    example.com.
    ```
 **Note**  
-Some DNS providers refer to the **Name** field as the **Host**, **Domain**, or **Mail Domain**\.
+Some DNS providers refer to the **Name** field as the **Host**, **Domain**, or **Mail Domain**\.  
+If you are using the Route 53 management console you can leave the MX record **Name** field blank, as it is already suffixed by your domain - even though it is not followed by a dot\.
 
 1. For **Type**, choose **MX**\.
 **Note**  


### PR DESCRIPTION
*Issue #, if available:*
Following the documentation to the letter would lead to creating a domainName.domainName. **Name** for the MX record.

*Description of changes:*
Added note stating that **Name** field can be left blank when using R53 Console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
