### PR TITLE
TYPO - remove duplicated instructions

### DIFF
--- a/doc-source/smtp-credentials.md
+++ b/doc-source/smtp-credentials.md
@@ -183,18 +183,3 @@ In the preceding command, do the following:
 + Replace *us\-east\-1* with the AWS Region in which you want to use the SMTP credentials\.
 
 When this script runs successfully, the only output is your SMTP password\.
-
-------
-
-To use this script, first save the preceding code as `smtp_credentials_generate.py`\. Then, at the command line, run the following command:
-
-```
-python path/to/smtp_credentials_generate.py wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY us-east-1
-```
-
-In the preceding command, do the following:
-+ Replace *path/to/* with the path to the location where you saved `smtp_credentials_generate.py`\.
-+ Replace *wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY* with the Secret Access Key that you want to convert into an SMTP password\.
-+ Replace *us\-east\-1* with the AWS Region in which you want to use the SMTP credentials\.
-
-When this script runs successfully, the only output is your SMTP password\.


### PR DESCRIPTION
The summary on running the python script seems to be explaining the same process twice. I have just removed the second entry on how to execute it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
