### PR TITLE
anaya.iyengar changed to anaya

### DIFF
--- a/doc-source/send-personalized-email-api.md
+++ b/doc-source/send-personalized-email-api.md
@@ -125,7 +125,7 @@ You can use the `SendBulkTemplatedEmail` operation to send an email to several d
        {
          "Destination":{
            "ToAddresses":[
-             "anaya.iyengar@example.com"
+             "anaya@example.com"
            ]
          },
          "ReplacementTemplateData":"{ \"name\":\"Anaya\", \"favoriteanimal\":\"angelfish\" }"


### PR DESCRIPTION
I wonder why caste name was used in the first place in an example email address.  Iyengar is an upper caste name in India.  Example email address in the aws document should not have caste name.  Hope this change is accepted.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
